### PR TITLE
Fix birthday banner width on mobile

### DIFF
--- a/public/js/birthday.js
+++ b/public/js/birthday.js
@@ -9,9 +9,10 @@
     announcement.style.position = 'fixed';
     announcement.style.top = '0';
     announcement.style.left = '0';
-    announcement.style.width = '100%';
+    announcement.style.right = '0';
     announcement.style.background = '#ffd';
     announcement.style.padding = '1em';
+    announcement.style.boxSizing = 'border-box';
     announcement.style.textAlign = 'center';
     announcement.style.zIndex = '1000';
     announcement.querySelectorAll('a').forEach(function(link) {

--- a/static/js/birthday.js
+++ b/static/js/birthday.js
@@ -9,9 +9,10 @@
     announcement.style.position = 'fixed';
     announcement.style.top = '0';
     announcement.style.left = '0';
-    announcement.style.width = '100%';
+    announcement.style.right = '0';
     announcement.style.background = '#ffd';
     announcement.style.padding = '1em';
+    announcement.style.boxSizing = 'border-box';
     announcement.style.textAlign = 'center';
     announcement.style.zIndex = '1000';
     announcement.querySelectorAll('a').forEach(function(link) {


### PR DESCRIPTION
## Summary
- avoid text cropping in birthday banner by using `right: 0` and `box-sizing: border-box`

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_688498b39f7c832483db1b0398cfd8ac